### PR TITLE
Fix the provider to error if the state of the cluster goes to 'error'

### DIFF
--- a/rancher2/resource_rancher2_cluster.go
+++ b/rancher2/resource_rancher2_cluster.go
@@ -265,6 +265,12 @@ func clusterStateRefreshFunc(client *managementClient.Client, clusterID string) 
 			return nil, "", err
 		}
 
+		// If we encounter an error, such as "only one of zone or region must be specified"
+		// on GCP for instance, that is not recoverable
+		if obj.Transitioning == "error" {
+			return nil, "", err
+		}
+
 		return obj, obj.State, nil
 	}
 }


### PR DESCRIPTION
This pull request aims at making the provider return if the cluster transitions to an error state, instead of hanging for ever

Tested and it returns as expected
```
* rancher2_cluster.gke_cluster: [ERROR] waiting for cluster (c-8nk4p) to be created: Cluster in error state: rpc error: code = Unknown desc = only one of zone or region must be specified
```