### PR TITLE
AKS tag->tags fix

### DIFF
--- a/rancher2/schema_cluster_aks_config.go
+++ b/rancher2/schema_cluster_aks_config.go
@@ -61,7 +61,7 @@ type AzureKubernetesServiceConfig struct {
 	ServiceCIDR                        string            `json:"serviceCidr,omitempty" yaml:"serviceCidr,omitempty"`
 	Subnet                             string            `json:"subnet,omitempty" yaml:"subnet,omitempty"`
 	SubscriptionID                     string            `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty"`
-	Tag                                map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Tags                               map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
 	TenantID                           string            `json:"tenantId,omitempty" yaml:"tenantId,omitempty"`
 	VirtualNetwork                     string            `json:"virtualNetwork,omitempty" yaml:"virtualNetwork,omitempty"`
 	VirtualNetworkResourceGroup        string            `json:"virtualNetworkResourceGroup,omitempty" yaml:"virtualNetworkResourceGroup,omitempty"`
@@ -276,7 +276,7 @@ func clusterAKSConfigFields() map[string]*schema.Schema {
 			Default:     "10.0.0.0/16",
 			Description: "A CIDR notation IP range from which to assign Kubernetes Service cluster IPs. It must not overlap with any Subnet IP ranges",
 		},
-		"tag": &schema.Schema{
+		"tags": &schema.Schema{
 			Type:        schema.TypeMap,
 			Optional:    true,
 			Computed:    true,

--- a/rancher2/structure_cluster_aks_config.go
+++ b/rancher2/structure_cluster_aks_config.go
@@ -156,8 +156,8 @@ func flattenClusterAKSConfig(in *AzureKubernetesServiceConfig) ([]interface{}, e
 		obj["subscription_id"] = in.SubscriptionID
 	}
 
-	if len(in.Tag) > 0 {
-		obj["tag"] = toMapInterface(in.Tag)
+	if len(in.Tags) > 0 {
+		obj["tags"] = toMapInterface(in.Tags)
 	}
 
 	if len(in.TenantID) > 0 {
@@ -357,8 +357,8 @@ func expandClusterAKSConfig(p []interface{}, name string) (*AzureKubernetesServi
 		obj.SubscriptionID = v
 	}
 
-	if v, ok := in["tag"].(map[string]interface{}); ok && len(v) > 0 {
-		obj.Tag = toMapString(v)
+	if v, ok := in["tags"].(map[string]interface{}); ok && len(v) > 0 {
+		obj.Tags = toMapString(v)
 	}
 
 	if v, ok := in["tenant_id"].(string); ok && len(v) > 0 {

--- a/rancher2/structure_cluster_aks_config_test.go
+++ b/rancher2/structure_cluster_aks_config_test.go
@@ -53,7 +53,7 @@ func init() {
 		ServiceCIDR:                        "service_cidr",
 		Subnet:                             "subnet",
 		SubscriptionID:                     "subscription_id",
-		Tag: map[string]string{
+		Tags: map[string]string{
 			"tag1": "value1",
 			"tag2": "value2",
 		},
@@ -102,7 +102,7 @@ func init() {
 			"service_cidr":                           "service_cidr",
 			"subnet":                                 "subnet",
 			"subscription_id":                        "subscription_id",
-			"tag": map[string]interface{}{
+			"tags": map[string]interface{}{
 				"tag1": "value1",
 				"tag2": "value2",
 			},

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -672,7 +672,7 @@ The following arguments are supported:
 * `network_policy` - (Optional) Network policy used for building Kubernetes network. Chooses from `calico` (string)
 * `pod_cidr` - (Optional) A CIDR notation IP range from which to assign Kubernetes Pod IPs when \"network plugin\" is specified in \"kubenet\". Default `172.244.0.0/16` (string)
 * `service_cidr` - (Optional) A CIDR notation IP range from which to assign Kubernetes Service cluster IPs. It must not overlap with any Subnet IP ranges. Default `10.0.0.0/16` (string)
-* `tag` - (Optional/Computed) Tags for Kubernetes cluster. For example, foo=bar (map)
+* `tags` - (Optional/Computed) Tags for Kubernetes cluster. For example, foo=bar (map)
 
 ### `eks_config`
 


### PR DESCRIPTION
What
----
AKS tag->tags fix
Terraform provider expects `tag` input.
Kontainer-engine code expects `tags` input.
Provider code doesn't appear adept to translating property name to `tag`->`tags`.
As the field has never worked anyway, it doesn't appear to be a major problem to rename `tag` to the correct pluralization `tags` throughout.

References
----
https://confluentinc.atlassian.net/browse/CIRE-1106

Testing
----
```
module.test_azure_uksouth.rancher2_cluster.aks_cluster: Creating...
*** snip ***
  aks_config.0.tags.%:                                 "0" => "1"
  aks_config.0.tags.Context:                           "" => "k8s-makefile-mz1.eastus2.azure.internal.devel.cpdev.cloud"
*** snip ***
```
