### PR TITLE
CIRE-1223 update eks cluster schema to support multiple worker pools

### DIFF
--- a/rancher2/schema_cluster_eks_config.go
+++ b/rancher2/schema_cluster_eks_config.go
@@ -12,31 +12,64 @@ const (
 //Types
 
 type AmazonElasticContainerServiceConfig struct {
+	AccessKey               string            `json:"accessKey,omitempty" yaml:"accessKey,omitempty"`
+	Annotations             map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	DisplayName             string            `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	DriverName              string            `json:"driverName" yaml:"driverName"`
+	KeyPairName             string            `json:"keyPairName,omitempty" yaml:"keyPairName,omitempty"`
+	KubernetesVersion       string            `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
+	ManageOwnSecurityGroups *bool             `json:"manageOwnSecurityGroups,omitempty" yaml:"manageOwnSecurityGroups,omitempty"`
+	NodeSecurityGroups      []string          `json:"nodeSecurityGroups,omitempty" yaml:"nodeSecurityGroups,omitempty"`
+	Region                  string            `json:"region,omitempty" yaml:"region,omitempty"`
+	SecretKey               string            `json:"secretKey,omitempty" yaml:"secretKey,omitempty"`
+	SecurityGroups          []string          `json:"securityGroups,omitempty" yaml:"securityGroups,omitempty"`
+	ServiceRole             string            `json:"serviceRole,omitempty" yaml:"serviceRole,omitempty"`
+	SessionToken            string            `json:"sessionToken,omitempty" yaml:"sessionToken,omitempty"`
+	Subnets                 []string          `json:"subnets,omitempty" yaml:"subnets,omitempty"`
+	VirtualNetwork          string            `json:"virtualNetwork,omitempty" yaml:"virtualNetwork,omitempty"`
+
+	// list of json objects. Each object matches the schema defined by `AmazonElasticContainerWorkerPool`
+	WorkerPools []string `json:"workerPools,omitempty" yaml:"workerPools,omitempty"`
+
+	// TODO remove fields from here on once all clusters have being migrated to new state (use "workerPools") in rancher
+	AMI                         string   `json:"ami,omitempty" yaml:"ami,omitempty"`
+	AssociateWorkerNodePublicIP *bool    `json:"associateWorkerNodePublicIp,omitempty" yaml:"associateWorkerNodePublicIp,omitempty"`
+	DesiredNodes                int64    `json:"desiredNodes,omitempty" yaml:"desiredNodes,omitempty"`
+	EBSEncryption               bool     `json:"ebsEncryption,omitempty" yaml:"ebsEncryption,omitempty"`
+	InstanceType                string   `json:"instanceType,omitempty" yaml:"instanceType,omitempty"`
+	MaximumNodes                int64    `json:"maximumNodes,omitempty" yaml:"maximumNodes,omitempty"`
+	MinimumNodes                int64    `json:"minimumNodes,omitempty" yaml:"minimumNodes,omitempty"`
+	Name                        string   `json:"name,omitempty" yaml:"name,omitempty"`
+	NodeVolumeSize              int64    `json:"nodeVolumeSize,omitempty" yaml:"nodeVolumeSize,omitempty"`
+	PlacementGroup              string   `json:"placementGroup,omitempty" yaml:"placementGroup,omitempty"`
+	UserData                    string   `json:"userData,omitempty" yaml:"userData,omitempty"`
+	WorkerSubnets               []string `json:"workerSubnets,omitempty" yaml:"workerSubnets,omitempty"`
+}
+
+type AmazonElasticContainerWorkerPool struct {
+	AddDefaultLabel             bool              `json:"addDefaultLabel,omitempty" yaml:"addDefaultLabel,omitempty"`
+	AddDefaultTaint             bool              `json:"addDefaultTaint,omitempty" yaml:"addDefaultTaint,omitempty"`
+	AdditionalLabels            map[string]string `json:"additionalLabels,omitempty" yaml:"additionalLabels,omitempty"`
+	AdditionalTaints            []K8sTaint        `json:"additionalTaints,omitempty" yaml:"additionalTaints,omitempty"`
 	AMI                         string            `json:"ami,omitempty" yaml:"ami,omitempty"`
-	AccessKey                   string            `json:"accessKey,omitempty" yaml:"accessKey,omitempty"`
-	Annotations                 map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	AssociateWorkerNodePublicIP *bool             `json:"associateWorkerNodePublicIp,omitempty" yaml:"associateWorkerNodePublicIp,omitempty"`
 	DesiredNodes                int64             `json:"desiredNodes,omitempty" yaml:"desiredNodes,omitempty"`
-	DisplayName                 string            `json:"displayName,omitempty" yaml:"displayName,omitempty"`
-	DriverName                  string            `json:"driverName" yaml:"driverName"`
+	EBSEncryption               bool              `json:"ebsEncryption,omitempty" yaml:"ebsEncryption,omitempty"`
 	InstanceType                string            `json:"instanceType,omitempty" yaml:"instanceType,omitempty"`
-	KeyPairName                 string            `json:"keyPairName,omitempty" yaml:"keyPairName,omitempty"`
-	KubernetesVersion           string            `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
-	ManageOwnSecurityGroups     *bool             `json:"manageOwnSecurityGroups,omitempty" yaml:"manageOwnSecurityGroups,omitempty"`
 	MaximumNodes                int64             `json:"maximumNodes,omitempty" yaml:"maximumNodes,omitempty"`
 	MinimumNodes                int64             `json:"minimumNodes,omitempty" yaml:"minimumNodes,omitempty"`
-	NodeSecurityGroups          []string          `json:"nodeSecurityGroups,omitempty" yaml:"nodeSecurityGroups,omitempty"`
+	Name                        string            `json:"name,omitempty" yaml:"name,omitempty"`
 	NodeVolumeSize              int64             `json:"nodeVolumeSize,omitempty" yaml:"nodeVolumeSize,omitempty"`
 	PlacementGroup              string            `json:"placementGroup,omitempty" yaml:"placementGroup,omitempty"`
-	Region                      string            `json:"region,omitempty" yaml:"region,omitempty"`
-	SecretKey                   string            `json:"secretKey,omitempty" yaml:"secretKey,omitempty"`
-	SecurityGroups              []string          `json:"securityGroups,omitempty" yaml:"securityGroups,omitempty"`
-	ServiceRole                 string            `json:"serviceRole,omitempty" yaml:"serviceRole,omitempty"`
-	SessionToken                string            `json:"sessionToken,omitempty" yaml:"sessionToken,omitempty"`
-	Subnets                     []string          `json:"subnets,omitempty" yaml:"subnets,omitempty"`
 	UserData                    string            `json:"userData,omitempty" yaml:"userData,omitempty"`
-	VirtualNetwork              string            `json:"virtualNetwork,omitempty" yaml:"virtualNetwork,omitempty"`
-	WorkerSubnets               []string          `json:"workerSubnets,omitempty" yaml:"workerSubnets,omitempty"`
+	Subnets                     []string          `json:"subnets,omitempty" yaml:"subnets,omitempty"`
+}
+
+type K8sTaint struct {
+	Effect   string `json:"effect,omitempty" yaml:"effect,omitempty"`
+	Operator string `json:"operator,omitempty" yaml:"operator,omitempty"`
+	Key      string `json:"key,omitempty" yaml:"key,omitempty"`
+	Value    string `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 //Schemas
@@ -60,35 +93,6 @@ func clusterEKSConfigFields() map[string]*schema.Schema {
 			Sensitive:   true,
 			Description: "The AWS Client Secret associated with the Client ID",
 		},
-		"ami": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "A custom AMI ID to use for the worker nodes instead of the default",
-		},
-		"associate_worker_node_public_ip": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     true,
-			Description: "Associate public ip EKS worker nodes",
-		},
-		"desired_nodes": {
-			Type:        schema.TypeInt,
-			Optional:    true,
-			Default:     3,
-			Description: "The desired number of worker nodes",
-		},
-		"instance_type": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     "t2.medium",
-			Description: "The type of machine to use for worker nodes",
-		},
-		"placement_group": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     "",
-			Description: "The name of an existing cluster placement group into which you want to launch your instances",
-		},
 		"key_pair_name": {
 			Type:        schema.TypeString,
 			Optional:    true,
@@ -100,18 +104,6 @@ func clusterEKSConfigFields() map[string]*schema.Schema {
 			Default:     false,
 			Description: "When true, do not create or edit security groups, only assign them",
 		},
-		"maximum_nodes": {
-			Type:        schema.TypeInt,
-			Optional:    true,
-			Default:     3,
-			Description: "The maximum number of worker nodes",
-		},
-		"minimum_nodes": {
-			Type:        schema.TypeInt,
-			Optional:    true,
-			Default:     1,
-			Description: "The minimum number of worker nodes",
-		},
 		"node_security_groups": {
 			Type:        schema.TypeList,
 			Optional:    true,
@@ -119,12 +111,6 @@ func clusterEKSConfigFields() map[string]*schema.Schema {
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},
-		},
-		"node_volume_size": {
-			Type:        schema.TypeInt,
-			Optional:    true,
-			Default:     20,
-			Description: "The volume size for each node",
 		},
 		"region": {
 			Type:        schema.TypeString,
@@ -159,23 +145,140 @@ func clusterEKSConfigFields() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
-		"user_data": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Computed:    true,
-			Description: "Pass user-data to the nodes to perform automated configuration tasks",
-		},
 		"virtual_network": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "The name of the virtual network to use",
 		},
-		"worker_subnets": {
+		"worker_pools": {
 			Type:        schema.TypeList,
-			Optional:    true,
-			Description: "List of worker subnets in the virtual network to use",
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
+			Required:    true,
+			Description: "List of worker pools",
+			MinItems:    1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"add_default_label": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Default:     false,
+						Description: "Adds default label for EKS worker nodes",
+					},
+					"add_default_taint": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Default:     false,
+						Description: "Adds default taint for EKS worker nodes",
+					},
+					"additional_labels": {
+						Type:        schema.TypeMap,
+						Optional:    true,
+						Description: "Additional labels for EKS worker nodes",
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+					"additional_taints": {
+						Type:        schema.TypeList,
+						Optional:    true,
+						Description: "List of additional taints",
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"effect": {
+									Type:     schema.TypeString,
+									Optional: true,
+									Default:  "",
+								},
+								"key": {
+									Type:     schema.TypeString,
+									Optional: true,
+									Default:  "",
+								},
+								"operator": {
+									Type:     schema.TypeString,
+									Optional: true,
+									Default:  "",
+								},
+								"value": {
+									Type:     schema.TypeString,
+									Optional: true,
+									Default:  "",
+								},
+							},
+						},
+					},
+					"ami": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "A custom AMI ID to use for the worker nodes instead of the default",
+					},
+					"associate_worker_node_public_ip": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Default:     true,
+						Description: "Associate public ip EKS worker nodes",
+					},
+					"desired_nodes": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Default:     3,
+						Description: "The desired number of worker nodes",
+					},
+					"ebs_encryption": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Default:     false,
+						Description: "Enable EBS encryption for EKS worker nodes",
+					},
+					"instance_type": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Default:     "t2.medium",
+						Description: "The type of machine to use for worker nodes",
+					},
+					"placement_group": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Default:     "",
+						Description: "The name of an existing cluster placement group into which you want to launch your instances",
+					},
+					"maximum_nodes": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Default:     3,
+						Description: "The maximum number of worker nodes",
+					},
+					"minimum_nodes": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Default:     1,
+						Description: "The minimum number of worker nodes",
+					},
+					"name": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "Name of the worker pool",
+					},
+					"node_volume_size": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Default:     20,
+						Description: "The volume size for each node",
+					},
+					"user_data": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Computed:    true,
+						Description: "Pass user-data to the nodes to perform automated configuration tasks",
+					},
+					"subnets": {
+						Type:        schema.TypeList,
+						Optional:    true,
+						Description: "List of worker subnets in the virtual network to use",
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
 			},
 		},
 	}

--- a/rancher2/structure_cluster_eks_config.go
+++ b/rancher2/structure_cluster_eks_config.go
@@ -1,5 +1,11 @@
 package rancher2
 
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
 // Flatteners
 
 func flattenClusterEKSConfig(in *AmazonElasticContainerServiceConfig) ([]interface{}, error) {
@@ -16,20 +22,6 @@ func flattenClusterEKSConfig(in *AmazonElasticContainerServiceConfig) ([]interfa
 		obj["secret_key"] = in.SecretKey
 	}
 
-	if len(in.AMI) > 0 {
-		obj["ami"] = in.AMI
-	}
-
-	obj["associate_worker_node_public_ip"] = *in.AssociateWorkerNodePublicIP
-
-	if in.DesiredNodes > 0 {
-		obj["desired_nodes"] = int(in.DesiredNodes)
-	}
-
-	if len(in.InstanceType) > 0 {
-		obj["instance_type"] = in.InstanceType
-	}
-
 	if len(in.KeyPairName) > 0 {
 		obj["key_pair_name"] = in.KeyPairName
 	}
@@ -40,28 +32,12 @@ func flattenClusterEKSConfig(in *AmazonElasticContainerServiceConfig) ([]interfa
 
 	obj["manage_own_security_groups"] = *in.ManageOwnSecurityGroups
 
-	if in.MaximumNodes > 0 {
-		obj["maximum_nodes"] = int(in.MaximumNodes)
-	}
-
-	if in.MinimumNodes > 0 {
-		obj["minimum_nodes"] = int(in.MinimumNodes)
-	}
-
 	if len(in.NodeSecurityGroups) > 0 {
 		obj["node_security_groups"] = toArrayInterface(in.NodeSecurityGroups)
 	}
 
-	if in.NodeVolumeSize > 0 {
-		obj["node_volume_size"] = int(in.NodeVolumeSize)
-	}
-
 	if len(in.Region) > 0 {
 		obj["region"] = in.Region
-	}
-
-	if len(in.PlacementGroup) > 0 {
-		obj["placement_group"] = in.PlacementGroup
 	}
 
 	if len(in.SecurityGroups) > 0 {
@@ -80,18 +56,154 @@ func flattenClusterEKSConfig(in *AmazonElasticContainerServiceConfig) ([]interfa
 		obj["subnets"] = toArrayInterface(in.Subnets)
 	}
 
-	if len(in.UserData) > 0 {
-		obj["user_data"] = in.UserData
-	}
-
 	if len(in.VirtualNetwork) > 0 {
 		obj["virtual_network"] = in.VirtualNetwork
 	}
 
-	if len(in.WorkerSubnets) > 0 {
-		obj["worker_subnets"] = toArrayInterface(in.WorkerSubnets)
+	var workerPoolObjs []interface{}
+	for _, workerPoolIn := range in.WorkerPools {
+		var workerPool AmazonElasticContainerWorkerPool
+		if err := json.Unmarshal([]byte(workerPoolIn), &workerPool); err != nil {
+			return nil, err
+		}
+
+		workerPoolObj := make(map[string]interface{})
+
+		workerPoolObj["add_default_label"] = workerPool.AddDefaultLabel
+		workerPoolObj["add_default_taint"] = workerPool.AddDefaultTaint
+
+		if len(workerPool.AdditionalLabels) > 0 {
+			additionalLabelsObj := make(map[string]interface{})
+			for key, value := range workerPool.AdditionalLabels {
+				additionalLabelsObj[key] = value
+			}
+			workerPoolObj["additional_labels"] = additionalLabelsObj
+		}
+
+		if len(workerPool.AdditionalTaints) > 0 {
+			additionalTaintObjs := make([]interface{}, 0, len(workerPool.AdditionalTaints))
+			for _, taint := range workerPool.AdditionalTaints {
+				additionalTaintObj := make(map[string]interface{})
+
+				if len(taint.Effect) > 0 {
+					additionalTaintObj["effect"] = taint.Effect
+				}
+
+				if len(taint.Key) > 0 {
+					additionalTaintObj["key"] = taint.Key
+				}
+
+				if len(taint.Operator) > 0 {
+					additionalTaintObj["operator"] = taint.Operator
+				}
+
+				if len(taint.Value) > 0 {
+					additionalTaintObj["value"] = taint.Value
+				}
+
+				additionalTaintObjs = append(additionalTaintObjs, additionalTaintObj)
+			}
+
+			workerPoolObj["additional_taints"] = additionalTaintObjs
+		}
+
+		if len(workerPool.AMI) > 0 {
+			workerPoolObj["ami"] = workerPool.AMI
+		}
+
+		workerPoolObj["associate_worker_node_public_ip"] = *workerPool.AssociateWorkerNodePublicIP
+
+		if workerPool.DesiredNodes > 0 {
+			workerPoolObj["desired_nodes"] = int(workerPool.DesiredNodes)
+		}
+
+		workerPoolObj["ebs_encryption"] = workerPool.EBSEncryption
+
+		if len(workerPool.InstanceType) > 0 {
+			workerPoolObj["instance_type"] = workerPool.InstanceType
+		}
+
+		if len(workerPool.Name) > 0 {
+			workerPoolObj["name"] = workerPool.Name
+		}
+
+		if workerPool.MaximumNodes > 0 {
+			workerPoolObj["maximum_nodes"] = int(workerPool.MaximumNodes)
+		}
+
+		if workerPool.MinimumNodes > 0 {
+			workerPoolObj["minimum_nodes"] = int(workerPool.MinimumNodes)
+		}
+
+		if workerPool.NodeVolumeSize > 0 {
+			workerPoolObj["node_volume_size"] = int(workerPool.NodeVolumeSize)
+		}
+
+		if len(workerPool.PlacementGroup) > 0 {
+			workerPoolObj["placement_group"] = workerPool.PlacementGroup
+		}
+
+		if len(workerPool.UserData) > 0 {
+			workerPoolObj["user_data"] = workerPool.UserData
+		}
+
+		if len(workerPool.Subnets) > 0 {
+			workerPoolObj["subnets"] = toArrayInterface(workerPool.Subnets)
+		}
+
+		workerPoolObjs = append(workerPoolObjs, workerPoolObj)
 	}
 
+	// when rancher returns details of a cluster that hasn't been migrated to new state model, we fallback to old
+	// fields to extract existing worker pool details
+	if len(workerPoolObjs) == 0 {
+		workerPoolObj := make(map[string]interface{})
+		workerPoolObj["name"] = "main-pool"
+
+		if len(in.AMI) > 0 {
+			workerPoolObj["ami"] = in.AMI
+		}
+
+		workerPoolObj["associate_worker_node_public_ip"] = *in.AssociateWorkerNodePublicIP
+
+		if in.DesiredNodes > 0 {
+			workerPoolObj["desired_nodes"] = int(in.DesiredNodes)
+		}
+
+		workerPoolObj["ebs_encryption"] = in.EBSEncryption
+
+		if len(in.InstanceType) > 0 {
+			workerPoolObj["instance_type"] = in.InstanceType
+		}
+
+		if in.MaximumNodes > 0 {
+			workerPoolObj["maximum_nodes"] = int(in.MaximumNodes)
+		}
+
+		if in.MinimumNodes > 0 {
+			workerPoolObj["minimum_nodes"] = int(in.MinimumNodes)
+		}
+
+		if in.NodeVolumeSize > 0 {
+			workerPoolObj["node_volume_size"] = int(in.NodeVolumeSize)
+		}
+
+		if len(in.PlacementGroup) > 0 {
+			workerPoolObj["placement_group"] = in.PlacementGroup
+		}
+
+		if len(in.UserData) > 0 {
+			workerPoolObj["user_data"] = in.UserData
+		}
+
+		if len(in.WorkerSubnets) > 0 {
+			workerPoolObj["subnets"] = toArrayInterface(in.WorkerSubnets)
+		}
+
+		workerPoolObjs = append(workerPoolObjs, workerPoolObj)
+	}
+
+	obj["worker_pools"] = workerPoolObjs
 	return []interface{}{obj}, nil
 }
 
@@ -113,22 +225,6 @@ func expandClusterEKSConfig(obj *AmazonElasticContainerServiceConfig, p []interf
 		obj.SecretKey = v
 	}
 
-	if v, ok := in["ami"].(string); ok && len(v) > 0 {
-		obj.AMI = v
-	}
-
-	if v, ok := in["associate_worker_node_public_ip"].(bool); ok {
-		obj.AssociateWorkerNodePublicIP = &v
-	}
-
-	if v, ok := in["desired_nodes"].(int); ok && v > 0 {
-		obj.DesiredNodes = int64(v)
-	}
-
-	if v, ok := in["instance_type"].(string); ok && len(v) > 0 {
-		obj.InstanceType = v
-	}
-
 	if v, ok := in["key_pair_name"].(string); ok && len(v) > 0 {
 		obj.KeyPairName = v
 	}
@@ -141,24 +237,8 @@ func expandClusterEKSConfig(obj *AmazonElasticContainerServiceConfig, p []interf
 		obj.ManageOwnSecurityGroups = &v
 	}
 
-	if v, ok := in["maximum_nodes"].(int); ok && v > 0 {
-		obj.MaximumNodes = int64(v)
-	}
-
-	if v, ok := in["minimum_nodes"].(int); ok && v > 0 {
-		obj.MinimumNodes = int64(v)
-	}
-
 	if v, ok := in["node_security_groups"].([]interface{}); ok && len(v) > 0 {
 		obj.NodeSecurityGroups = toArrayString(v)
-	}
-
-	if v, ok := in["node_volume_size"].(int); ok && v > 0 {
-		obj.NodeVolumeSize = int64(v)
-	}
-
-	if v, ok := in["placement_group"].(string); ok && len(v) > 0 {
-		obj.PlacementGroup = v
 	}
 
 	if v, ok := in["region"].(string); ok && len(v) > 0 {
@@ -181,21 +261,146 @@ func expandClusterEKSConfig(obj *AmazonElasticContainerServiceConfig, p []interf
 		obj.Subnets = toArrayString(v)
 	}
 
-	if v, ok := in["user_data"].(string); ok && len(v) > 0 {
-		obj.UserData = v
-	}
-
 	if v, ok := in["virtual_network"].(string); ok && len(v) > 0 {
 		obj.VirtualNetwork = v
 	}
 
-	if v, ok := in["worker_subnets"].([]interface{}); ok && len(v) > 0 {
-		obj.WorkerSubnets = toArrayString(v)
+	var workerPoolObjs []string
+
+	if vs, ok := in["worker_pools"]; ok {
+		if workerPoolIns, ok := vs.([]interface{}); !ok {
+			return nil, errors.New("unexpected content in 'worker_pools'")
+		} else if len(workerPoolIns) > 0 {
+			for index, v := range workerPoolIns {
+				if workerPoolIn, ok := v.(map[string]interface{}); ok {
+					workerPoolObj, err := expandWorkerPool(workerPoolIn)
+					if err != nil {
+						return nil, err
+					}
+
+					workerPoolObjs = append(workerPoolObjs, workerPoolObj)
+				} else {
+					return nil, fmt.Errorf("unexpected content in worker_pool with index %d", index)
+				}
+			}
+		}
 	}
 
-	if obj.DesiredNodes == 0 {
-		obj.DesiredNodes = obj.MinimumNodes
-	}
-
+	obj.WorkerPools = workerPoolObjs
 	return obj, nil
+}
+
+func expandWorkerPool(workerPoolIn map[string]interface{}) (string, error) {
+	var workerPoolObj AmazonElasticContainerWorkerPool
+
+	if v, ok := workerPoolIn["ami"].(string); ok && len(v) > 0 {
+		workerPoolObj.AMI = v
+	}
+
+	if v, ok := workerPoolIn["associate_worker_node_public_ip"].(bool); ok {
+		workerPoolObj.AssociateWorkerNodePublicIP = &v
+	}
+
+	if v, ok := workerPoolIn["desired_nodes"].(int); ok && v > 0 {
+		workerPoolObj.DesiredNodes = int64(v)
+	}
+
+	if v, ok := workerPoolIn["ebs_encryption"].(bool); ok {
+		workerPoolObj.EBSEncryption = v
+	}
+
+	if v, ok := workerPoolIn["instance_type"].(string); ok && len(v) > 0 {
+		workerPoolObj.InstanceType = v
+	}
+
+	if v, ok := workerPoolIn["maximum_nodes"].(int); ok && v > 0 {
+		workerPoolObj.MaximumNodes = int64(v)
+	}
+
+	if v, ok := workerPoolIn["minimum_nodes"].(int); ok && v > 0 {
+		workerPoolObj.MinimumNodes = int64(v)
+	}
+
+	if v, ok := workerPoolIn["node_volume_size"].(int); ok && v > 0 {
+		workerPoolObj.NodeVolumeSize = int64(v)
+	}
+
+	if v, ok := workerPoolIn["placement_group"].(string); ok && len(v) > 0 {
+		workerPoolObj.PlacementGroup = v
+	}
+
+	if v, ok := workerPoolIn["user_data"].(string); ok && len(v) > 0 {
+		workerPoolObj.UserData = v
+	}
+
+	if workerPoolObj.DesiredNodes == 0 {
+		workerPoolObj.DesiredNodes = workerPoolObj.MinimumNodes
+	}
+
+	if v, ok := workerPoolIn["name"].(string); ok && len(v) > 0 {
+		workerPoolObj.Name = v
+	}
+
+	if v, ok := workerPoolIn["add_default_label"].(bool); ok {
+		workerPoolObj.AddDefaultLabel = v
+	}
+
+	if v, ok := workerPoolIn["add_default_taint"].(bool); ok {
+		workerPoolObj.AddDefaultTaint = v
+	}
+
+	if v, ok := workerPoolIn["additional_labels"].(map[string]interface{}); ok && len(v) > 0 {
+		workerPoolObj.AdditionalLabels = toMapString(v)
+	}
+
+	if v, ok := workerPoolIn["additional_taints"].([]interface{}); ok && len(v) > 0 {
+		additionalTaintsObjs, err := expandWorkerPoolAdditionalTaints(v, workerPoolObj.Name)
+		if err != nil {
+			return "", err
+		}
+
+		workerPoolObj.AdditionalTaints = additionalTaintsObjs
+	}
+
+	if v, ok := workerPoolIn["subnets"].([]interface{}); ok && len(v) > 0 {
+		workerPoolObj.Subnets = toArrayString(v)
+	}
+
+	bs, err := json.Marshal(workerPoolObj)
+	if err != nil {
+		return "", err
+	}
+
+	return string(bs), nil
+}
+
+func expandWorkerPoolAdditionalTaints(additionalTaintsIn []interface{}, poolName string) ([]K8sTaint, error) {
+	additionalTaintsObjs := make([]K8sTaint, 0, len(additionalTaintsIn))
+	for index, additionalTaintIn := range additionalTaintsIn {
+		if t, ok := additionalTaintIn.(map[string]interface{}); ok {
+			taint := toMapString(t)
+			additionalTaintsObj := K8sTaint{}
+
+			if effect, ok := taint["effect"]; ok && len(effect) > 0 {
+				additionalTaintsObj.Effect = effect
+			}
+
+			if operator, ok := taint["operator"]; ok && len(operator) > 0 {
+				additionalTaintsObj.Operator = operator
+			}
+
+			if key, ok := taint["key"]; ok && len(key) > 0 {
+				additionalTaintsObj.Key = key
+			}
+
+			if value, ok := taint["value"]; ok && len(value) > 0 {
+				additionalTaintsObj.Value = value
+			}
+
+			additionalTaintsObjs = append(additionalTaintsObjs, additionalTaintsObj)
+		} else {
+			return nil, fmt.Errorf("taint in index %d for worker pool %s contains unexpected content", index, poolName)
+		}
+	}
+	return additionalTaintsObjs, nil
 }

--- a/rancher2/structure_cluster_eks_config_test.go
+++ b/rancher2/structure_cluster_eks_config_test.go
@@ -1,6 +1,7 @@
 package rancher2
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -11,55 +12,96 @@ var (
 )
 
 func init() {
+	workerPoolBytes, _ := json.Marshal(
+		AmazonElasticContainerWorkerPool{
+			AddDefaultLabel: false,
+			AddDefaultTaint: false,
+			AdditionalLabels: map[string]string{
+				"pool-name": "main-pool",
+			},
+			AdditionalTaints: []K8sTaint{
+				{
+					Key:      "pool-name",
+					Operator: "Equal",
+					Value:    "main-pool",
+					Effect:   "NoSchedule",
+				},
+			},
+			AMI:                         "ami",
+			AssociateWorkerNodePublicIP: newTrue(),
+			DesiredNodes:                4,
+			InstanceType:                "instance",
+			MaximumNodes:                5,
+			MinimumNodes:                3,
+			Name:                        "main-pool",
+			NodeVolumeSize:              40,
+			PlacementGroup:              "placement_group",
+			UserData:                    "user_data",
+			Subnets:                     []string{"worker1", "worker2"},
+		},
+	)
+
 	testClusterEKSConfigConf = &AmazonElasticContainerServiceConfig{
-		AccessKey:                   "XXXXXXXX",
-		SecretKey:                   "YYYYYYYY",
-		AMI:                         "ami",
-		AssociateWorkerNodePublicIP: newTrue(),
-		DesiredNodes:                4,
-		DisplayName:                 "test",
-		InstanceType:                "instance",
-		KeyPairName:                 "key_pair_name",
-		KubernetesVersion:           "1.11",
-		ManageOwnSecurityGroups:     newTrue(),
-		MaximumNodes:                5,
-		MinimumNodes:                3,
-		NodeSecurityGroups:          []string{"node-sg1", "node-sg2"},
-		NodeVolumeSize:              40,
-		PlacementGroup:              "placement_group",
-		Region:                      "region",
-		SecurityGroups:              []string{"sg1", "sg2"},
-		ServiceRole:                 "role",
-		SessionToken:                "session_token",
-		Subnets:                     []string{"subnet1", "subnet2"},
-		UserData:                    "user_data",
-		VirtualNetwork:              "network",
-		WorkerSubnets:               []string{"worker1", "worker2"},
+		AccessKey:               "XXXXXXXX",
+		SecretKey:               "YYYYYYYY",
+		DisplayName:             "test",
+		KeyPairName:             "key_pair_name",
+		KubernetesVersion:       "1.11",
+		ManageOwnSecurityGroups: newTrue(),
+		NodeSecurityGroups:      []string{"node-sg1", "node-sg2"},
+		Region:                  "region",
+		SecurityGroups:          []string{"sg1", "sg2"},
+		ServiceRole:             "role",
+		SessionToken:            "session_token",
+		Subnets:                 []string{"subnet1", "subnet2"},
+		VirtualNetwork:          "network",
+		WorkerPools: []string{
+			string(workerPoolBytes),
+		},
 	}
 	testClusterEKSConfigInterface = []interface{}{
 		map[string]interface{}{
-			"access_key":                      "XXXXXXXX",
-			"secret_key":                      "YYYYYYYY",
-			"ami":                             "ami",
-			"associate_worker_node_public_ip": true,
-			"desired_nodes":                   4,
-			"instance_type":                   "instance",
-			"key_pair_name":                   "key_pair_name",
-			"kubernetes_version":              "1.11",
-			"manage_own_security_groups":      true,
-			"maximum_nodes":                   5,
-			"minimum_nodes":                   3,
-			"node_security_groups":            []interface{}{"node-sg1", "node-sg2"},
-			"node_volume_size":                40,
-			"placement_group":                 "placement_group",
-			"region":                          "region",
-			"security_groups":                 []interface{}{"sg1", "sg2"},
-			"service_role":                    "role",
-			"session_token":                   "session_token",
-			"subnets":                         []interface{}{"subnet1", "subnet2"},
-			"user_data":                       "user_data",
-			"virtual_network":                 "network",
-			"worker_subnets":                  []interface{}{"worker1", "worker2"},
+			"access_key":                 "XXXXXXXX",
+			"secret_key":                 "YYYYYYYY",
+			"key_pair_name":              "key_pair_name",
+			"kubernetes_version":         "1.11",
+			"manage_own_security_groups": true,
+			"node_security_groups":       []interface{}{"node-sg1", "node-sg2"},
+			"region":                     "region",
+			"security_groups":            []interface{}{"sg1", "sg2"},
+			"service_role":               "role",
+			"session_token":              "session_token",
+			"subnets":                    []interface{}{"subnet1", "subnet2"},
+			"virtual_network":            "network",
+			"worker_pools": []interface{}{
+				map[string]interface{}{
+					"add_default_label": false,
+					"add_default_taint": false,
+					"additional_labels": map[string]interface{}{
+						"pool-name": "main-pool",
+					},
+					"additional_taints": []interface{}{
+						map[string]interface{}{
+							"key":      "pool-name",
+							"operator": "Equal",
+							"value":    "main-pool",
+							"effect":   "NoSchedule",
+						},
+					},
+					"ami":                             "ami",
+					"associate_worker_node_public_ip": true,
+					"desired_nodes":                   4,
+					"ebs_encryption":                  false,
+					"instance_type":                   "instance",
+					"maximum_nodes":                   5,
+					"minimum_nodes":                   3,
+					"name":                            "main-pool",
+					"node_volume_size":                40,
+					"placement_group":                 "placement_group",
+					"user_data":                       "user_data",
+					"subnets":                         []interface{}{"worker1", "worker2"},
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
What?
------

Update EKS fields to use the `workerPools` field from rancher's API. 
I tried to support previous versions of the terraform module at the same time but it's quite tricky to define everything fields properly so the terraform diff gets properly generated.

I'll submit a PR to the module that is compatible with this code before merging. 

References
----------
https://confluentinc.atlassian.net/browse/CIRE-1223