### PR TITLE
CIRE-1487 fix GKE cluster updates

### DIFF
--- a/rancher2/resource_rancher2_cluster.go
+++ b/rancher2/resource_rancher2_cluster.go
@@ -220,7 +220,7 @@ func resourceRancher2ClusterUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 		update["amazonElasticContainerServiceConfig"] = eksConfig
 	case clusterDriverGKE:
-		gkeConfig, err := expandClusterGKEConfig(d.Get("gke_config").([]interface{}), d.Get("name").(string))
+		gkeConfig, err := expandClusterGKEConfig(cluster.GoogleKubernetesEngineConfig, d.Get("gke_config").([]interface{}), d.Get("name").(string))
 		if err != nil {
 			return err
 		}

--- a/rancher2/schema_cluster_gke_config.go
+++ b/rancher2/schema_cluster_gke_config.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	clusterGKEKind   = "gke"
-	clusterDriverGKE = "googlekubernetesengine"
+	clusterDriverGKE = "googleKubernetesEngine"
 )
 
 //Types
@@ -18,6 +18,7 @@ type GoogleKubernetesEngineConfig struct {
 	DiskSizeGb                         int64             `json:"diskSizeGb,omitempty" yaml:"diskSizeGb,omitempty"`
 	DiskType                           string            `json:"diskType,omitempty" yaml:"diskType,omitempty"`
 	DisplayName                        string            `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	DriverName                         string            `json:"driverName" yaml:"driverName"`
 	EnableAlphaFeature                 bool              `json:"enableAlphaFeature,omitempty" yaml:"enableAlphaFeature,omitempty"`
 	EnableAutoRepair                   bool              `json:"enableAutoRepair,omitempty" yaml:"enableAutoRepair,omitempty"`
 	EnableAutoUpgrade                  bool              `json:"enableAutoUpgrade,omitempty" yaml:"enableAutoUpgrade,omitempty"`

--- a/rancher2/structure_cluster.go
+++ b/rancher2/structure_cluster.go
@@ -318,7 +318,7 @@ func expandCluster(in *schema.ResourceData) (*Cluster, error) {
 	}
 
 	if v, ok := in.Get("gke_config").([]interface{}); ok && len(v) > 0 {
-		gkeConfig, err := expandClusterGKEConfig(v, obj.Name)
+		gkeConfig, err := expandClusterGKEConfig(&GoogleKubernetesEngineConfig{}, v, obj.Name)
 		if err != nil {
 			return nil, err
 		}

--- a/rancher2/structure_cluster_gke_config.go
+++ b/rancher2/structure_cluster_gke_config.go
@@ -198,8 +198,7 @@ func flattenClusterGKEConfig(in *GoogleKubernetesEngineConfig) ([]interface{}, e
 
 // Expanders
 
-func expandClusterGKEConfig(p []interface{}, name string) (*GoogleKubernetesEngineConfig, error) {
-	obj := &GoogleKubernetesEngineConfig{}
+func expandClusterGKEConfig(obj *GoogleKubernetesEngineConfig, p []interface{}, name string) (*GoogleKubernetesEngineConfig, error) {
 	if len(p) == 0 || p[0] == nil {
 		return obj, nil
 	}

--- a/rancher2/structure_cluster_gke_config_test.go
+++ b/rancher2/structure_cluster_gke_config_test.go
@@ -180,7 +180,7 @@ func TestExpandClusterGKEConfig(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		output, err := expandClusterGKEConfig(tc.Input, "test")
+		output, err := expandClusterGKEConfig(&GoogleKubernetesEngineConfig{}, tc.Input, "test")
 		if err != nil {
 			t.Fatalf("[ERROR] on expander: %#v", err)
 		}


### PR DESCRIPTION
What
----
Fix GKE driver string and send `driverName` field in updates.
This PR is based on required changes to fix EKS updates
https://github.com/confluentinc/terraform-provider-rancher2/commit/42dadbf80aa521cf510de069e6ef437456dd3ebe

Test & Review
-------
Provider built and tested locally