### PR TITLE
remove deprecated EKS fields

### DIFF
--- a/rancher2/schema_cluster_eks_config.go
+++ b/rancher2/schema_cluster_eks_config.go
@@ -30,20 +30,6 @@ type AmazonElasticContainerServiceConfig struct {
 
 	// list of json objects. Each object matches the schema defined by `AmazonElasticContainerWorkerPool`
 	WorkerPools []string `json:"workerPools,omitempty" yaml:"workerPools,omitempty"`
-
-	// TODO remove fields from here on once all clusters have being migrated to new state (use "workerPools") in rancher
-	AMI                         string   `json:"ami,omitempty" yaml:"ami,omitempty"`
-	AssociateWorkerNodePublicIP *bool    `json:"associateWorkerNodePublicIp,omitempty" yaml:"associateWorkerNodePublicIp,omitempty"`
-	DesiredNodes                int64    `json:"desiredNodes,omitempty" yaml:"desiredNodes,omitempty"`
-	EBSEncryption               bool     `json:"ebsEncryption,omitempty" yaml:"ebsEncryption,omitempty"`
-	InstanceType                string   `json:"instanceType,omitempty" yaml:"instanceType,omitempty"`
-	MaximumNodes                int64    `json:"maximumNodes,omitempty" yaml:"maximumNodes,omitempty"`
-	MinimumNodes                int64    `json:"minimumNodes,omitempty" yaml:"minimumNodes,omitempty"`
-	Name                        string   `json:"name,omitempty" yaml:"name,omitempty"`
-	NodeVolumeSize              int64    `json:"nodeVolumeSize,omitempty" yaml:"nodeVolumeSize,omitempty"`
-	PlacementGroup              string   `json:"placementGroup,omitempty" yaml:"placementGroup,omitempty"`
-	UserData                    string   `json:"userData,omitempty" yaml:"userData,omitempty"`
-	WorkerSubnets               []string `json:"workerSubnets,omitempty" yaml:"workerSubnets,omitempty"`
 }
 
 type AmazonElasticContainerWorkerPool struct {

--- a/rancher2/structure_cluster_eks_config.go
+++ b/rancher2/structure_cluster_eks_config.go
@@ -154,55 +154,6 @@ func flattenClusterEKSConfig(in *AmazonElasticContainerServiceConfig) ([]interfa
 		workerPoolObjs = append(workerPoolObjs, workerPoolObj)
 	}
 
-	// when rancher returns details of a cluster that hasn't been migrated to new state model, we fallback to old
-	// fields to extract existing worker pool details
-	if len(workerPoolObjs) == 0 {
-		workerPoolObj := make(map[string]interface{})
-		workerPoolObj["name"] = "main-pool"
-
-		if len(in.AMI) > 0 {
-			workerPoolObj["ami"] = in.AMI
-		}
-
-		workerPoolObj["associate_worker_node_public_ip"] = *in.AssociateWorkerNodePublicIP
-
-		if in.DesiredNodes > 0 {
-			workerPoolObj["desired_nodes"] = int(in.DesiredNodes)
-		}
-
-		workerPoolObj["ebs_encryption"] = in.EBSEncryption
-
-		if len(in.InstanceType) > 0 {
-			workerPoolObj["instance_type"] = in.InstanceType
-		}
-
-		if in.MaximumNodes > 0 {
-			workerPoolObj["maximum_nodes"] = int(in.MaximumNodes)
-		}
-
-		if in.MinimumNodes > 0 {
-			workerPoolObj["minimum_nodes"] = int(in.MinimumNodes)
-		}
-
-		if in.NodeVolumeSize > 0 {
-			workerPoolObj["node_volume_size"] = int(in.NodeVolumeSize)
-		}
-
-		if len(in.PlacementGroup) > 0 {
-			workerPoolObj["placement_group"] = in.PlacementGroup
-		}
-
-		if len(in.UserData) > 0 {
-			workerPoolObj["user_data"] = in.UserData
-		}
-
-		if len(in.WorkerSubnets) > 0 {
-			workerPoolObj["subnets"] = toArrayInterface(in.WorkerSubnets)
-		}
-
-		workerPoolObjs = append(workerPoolObjs, workerPoolObj)
-	}
-
 	obj["worker_pools"] = workerPoolObjs
 	return []interface{}{obj}, nil
 }


### PR DESCRIPTION
What
----
As part of the work in CIRE-1223, support for multiple worker pools
was implemented for EKS.

Temporarily, Rancher's legacy API fields were supported as some clusters
could still have not been migrated. This fields are not require any
more.

References
---------
https://confluentinc.atlassian.net/browse/CIRE-1223

Test&Review
-----------
Cluster creation & update