### PR TITLE
CIRE-1512 allow setting EKS minimum nodes to 0

### DIFF
--- a/rancher2/schema_cluster_eks_config.go
+++ b/rancher2/schema_cluster_eks_config.go
@@ -43,7 +43,7 @@ type AmazonElasticContainerWorkerPool struct {
 	EBSEncryption               bool              `json:"ebsEncryption,omitempty" yaml:"ebsEncryption,omitempty"`
 	InstanceType                string            `json:"instanceType,omitempty" yaml:"instanceType,omitempty"`
 	MaximumNodes                int64             `json:"maximumNodes,omitempty" yaml:"maximumNodes,omitempty"`
-	MinimumNodes                int64             `json:"minimumNodes,omitempty" yaml:"minimumNodes,omitempty"`
+	MinimumNodes                int64             `json:"minimumNodes" yaml:"minimumNodes"`
 	Name                        string            `json:"name,omitempty" yaml:"name,omitempty"`
 	NodeVolumeSize              int64             `json:"nodeVolumeSize,omitempty" yaml:"nodeVolumeSize,omitempty"`
 	PlacementGroup              string            `json:"placementGroup,omitempty" yaml:"placementGroup,omitempty"`


### PR DESCRIPTION
What
----
Allow configuring a worker pool with minimum nodes to 0.
`omitempty` does not set the field when serialising if an
int field's value is 0.

References
----------
https://confluentinc.atlassian.net/browse/CIRE-1512
https://github.com/confluentinc/kontainer-engine/pull/52

Test&Review
------
EKS cluster created with one worker pool with minimum
nodes set to 0