### PR TITLE
CIRE-1952 fix AKS cluster updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/terraform-providers/terraform-provider-rancher2
 go 1.12
 
 require (
+	github.com/google/btree v1.0.0 // indirect
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
 	github.com/rancher/norman v0.0.0-20191003174345-0ac7dd6ccb36

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,7 @@ github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/rancher2/resource_rancher2_cluster.go
+++ b/rancher2/resource_rancher2_cluster.go
@@ -208,7 +208,7 @@ func resourceRancher2ClusterUpdate(d *schema.ResourceData, meta interface{}) err
 
 	switch driver := d.Get("driver").(string); driver {
 	case clusterDriverAKS:
-		aksConfig, err := expandClusterAKSConfig(d.Get("aks_config").([]interface{}), d.Get("name").(string))
+		aksConfig, err := expandClusterAKSConfig(cluster.AzureKubernetesServiceConfig, d.Get("aks_config").([]interface{}), d.Get("name").(string))
 		if err != nil {
 			return err
 		}

--- a/rancher2/schema_cluster_aks_config.go
+++ b/rancher2/schema_cluster_aks_config.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	clusterAKSKind   = "aks"
-	clusterDriverAKS = "azurekubernetesservice"
+	clusterDriverAKS = "azureKubernetesService"
 )
 
 var (
@@ -40,6 +40,7 @@ type AzureKubernetesServiceConfig struct {
 	DisplayName                        string            `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	DNSServiceIP                       string            `json:"dnsServiceIp,omitempty" yaml:"dnsServiceIp,omitempty"`
 	DockerBridgeCIDR                   string            `json:"dockerBridgeCidr,omitempty" yaml:"dockerBridgeCidr,omitempty"`
+	DriverName                         string            `json:"driverName" yaml:"driverName"`
 	EnableAutoScaling                  *bool             `json:"enableAutoScaling,omitempty" yaml:"enableAutoScaling,omitempty"`
 	EnableHTTPApplicationRouting       bool              `json:"enableHttpApplicationRouting,omitempty" yaml:"enableHttpApplicationRouting,omitempty"`
 	EnableMonitoring                   *bool             `json:"enableMonitoring,omitempty" yaml:"enableMonitoring,omitempty"`

--- a/rancher2/structure_cluster.go
+++ b/rancher2/structure_cluster.go
@@ -300,7 +300,7 @@ func expandCluster(in *schema.ResourceData) (*Cluster, error) {
 	}
 
 	if v, ok := in.Get("aks_config").([]interface{}); ok && len(v) > 0 {
-		aksConfig, err := expandClusterAKSConfig(v, obj.Name)
+		aksConfig, err := expandClusterAKSConfig(&AzureKubernetesServiceConfig{}, v, obj.Name)
 		if err != nil {
 			return nil, err
 		}

--- a/rancher2/structure_cluster_aks_config.go
+++ b/rancher2/structure_cluster_aks_config.go
@@ -191,8 +191,7 @@ func flattenClusterAKSConfig(in *AzureKubernetesServiceConfig) ([]interface{}, e
 
 // Expanders
 
-func expandClusterAKSConfig(p []interface{}, name string) (*AzureKubernetesServiceConfig, error) {
-	obj := &AzureKubernetesServiceConfig{}
+func expandClusterAKSConfig(obj *AzureKubernetesServiceConfig, p []interface{}, name string) (*AzureKubernetesServiceConfig, error) {
 	if len(p) == 0 || p[0] == nil {
 		return obj, nil
 	}

--- a/rancher2/structure_cluster_aks_config_test.go
+++ b/rancher2/structure_cluster_aks_config_test.go
@@ -150,7 +150,7 @@ func TestExpandClusterAKSConfig(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		output, err := expandClusterAKSConfig(tc.Input, "test")
+		output, err := expandClusterAKSConfig(&AzureKubernetesServiceConfig{}, tc.Input, "test")
 		if err != nil {
 			t.Fatalf("[ERROR] on expander: %#v", err)
 		}


### PR DESCRIPTION
What
----
As for other kontainer-engine drivers [1][2], the Azure driver was
able to perform cluster updates.

Fixing the driver name constant to have the right casing and adding
driver name field to `AzureKubernetesServiceConfig`.

References
----
[1] https://github.com/confluentinc/terraform-provider-rancher2/pull/7
[2] https://github.com/confluentinc/terraform-provider-rancher2/pull/21
Jira: https://confluentinc.atlassian.net/browse/CIRE-1952

Test&Review
----
Two tests performed:
1. Create a cluster with old plugin and update it with plugin built with
   changes in PR
2. Create a cluster and update it with plugin built with changes in PR