### PR TITLE
CIRE-1952 support for multiple node pools for AKS

### DIFF
--- a/rancher2/schema_cluster_aks_config.go
+++ b/rancher2/schema_cluster_aks_config.go
@@ -25,23 +25,15 @@ type AzureKubernetesServiceConfig struct {
 	AADServerAppSecret                 string            `json:"addServerAppSecret,omitempty" yaml:"addServerAppSecret,omitempty"`
 	AADTenantID                        string            `json:"addTenantId,omitempty" yaml:"addTenantId,omitempty"`
 	AdminUsername                      string            `json:"adminUsername,omitempty" yaml:"adminUsername,omitempty"`
-	AgentDNSPrefix                     string            `json:"agentDnsPrefix,omitempty" yaml:"agentDnsPrefix,omitempty"`
-	AgentOsdiskSizeGB                  int64             `json:"agentOsdiskSize,omitempty" yaml:"agentOsdiskSize,omitempty"`
-	AgentPoolName                      string            `json:"agentPoolName,omitempty" yaml:"agentPoolName,omitempty"`
-	AgentPoolType                      string            `json:"agentPoolType,omitempty" yaml:"agentPoolType,omitempty"`
 	AgentStorageProfile                string            `json:"agentStorageProfile,omitempty" yaml:"agentStorageProfile,omitempty"`
-	AgentVMSize                        string            `json:"agentVmSize,omitempty" yaml:"agentVmSize,omitempty"`
 	AuthBaseURL                        string            `json:"authBaseUrl" yaml:"authBaseUrl"`
-	AvailabilityZones                  []string          `json:"availabilityZones,omitempty" yaml:"availabilityZones,omitempty"`
 	BaseURL                            string            `json:"baseUrl,omitempty" yaml:"baseUrl,omitempty"`
 	ClientID                           string            `json:"clientId,omitempty" yaml:"clientId,omitempty"`
 	ClientSecret                       string            `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
-	Count                              int64             `json:"count,omitempty" yaml:"count,omitempty"`
 	DisplayName                        string            `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	DNSServiceIP                       string            `json:"dnsServiceIp,omitempty" yaml:"dnsServiceIp,omitempty"`
 	DockerBridgeCIDR                   string            `json:"dockerBridgeCidr,omitempty" yaml:"dockerBridgeCidr,omitempty"`
 	DriverName                         string            `json:"driverName" yaml:"driverName"`
-	EnableAutoScaling                  *bool             `json:"enableAutoScaling,omitempty" yaml:"enableAutoScaling,omitempty"`
 	EnableHTTPApplicationRouting       bool              `json:"enableHttpApplicationRouting,omitempty" yaml:"enableHttpApplicationRouting,omitempty"`
 	EnableMonitoring                   *bool             `json:"enableMonitoring,omitempty" yaml:"enableMonitoring,omitempty"`
 	KubernetesVersion                  string            `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
@@ -50,9 +42,6 @@ type AzureKubernetesServiceConfig struct {
 	LogAnalyticsWorkspace              string            `json:"logAnalyticsWorkspace,omitempty" yaml:"logAnalyticsWorkspace,omitempty"`
 	LogAnalyticsWorkspaceResourceGroup string            `json:"logAnalyticsWorkspaceResourceGroup,omitempty" yaml:"logAnalyticsWorkspaceResourceGroup,omitempty"`
 	MasterDNSPrefix                    string            `json:"masterDnsPrefix,omitempty" yaml:"masterDnsPrefix,omitempty"`
-	MaxPods                            int64             `json:"maxPods,omitempty" yaml:"maxPods,omitempty"`
-	MaxCount                           int64             `json:"maxCount,omitempty" yaml:"maxCount,omitempty"`
-	MinCount                           int64             `json:"minCount,omitempty" yaml:"minCount,omitempty"`
 	Name                               string            `json:"name,omitempty" yaml:"name,omitempty"`
 	NetworkPlugin                      string            `json:"networkPlugin,omitempty" yaml:"networkPlugin,omitempty"`
 	NetworkPolicy                      string            `json:"networkPolicy,omitempty" yaml:"networkPolicy,omitempty"`
@@ -66,6 +55,39 @@ type AzureKubernetesServiceConfig struct {
 	TenantID                           string            `json:"tenantId,omitempty" yaml:"tenantId,omitempty"`
 	VirtualNetwork                     string            `json:"virtualNetwork,omitempty" yaml:"virtualNetwork,omitempty"`
 	VirtualNetworkResourceGroup        string            `json:"virtualNetworkResourceGroup,omitempty" yaml:"virtualNetworkResourceGroup,omitempty"`
+
+	// list of json objects. Each object matches the schema defined by `AzureKubernetesServiceNodePool`
+	NodePools []string `json:"nodePools,omitempty" yaml:"nodePools,omitempty"`
+
+	// TODO remove fields from here on once all clusters have being migrated to new state (use "nodePools") in rancher
+	AgentOsdiskSizeGB int64    `json:"agentOsdiskSize,omitempty" yaml:"agentOsdiskSize,omitempty"`
+	AgentPoolName     string   `json:"agentPoolName,omitempty" yaml:"agentPoolName,omitempty"`
+	AgentPoolType     string   `json:"agentPoolType,omitempty" yaml:"agentPoolType,omitempty"`
+	AgentVMSize       string   `json:"agentVmSize,omitempty" yaml:"agentVmSize,omitempty"`
+	AvailabilityZones []string `json:"availabilityZones,omitempty" yaml:"availabilityZones,omitempty"`
+	EnableAutoScaling *bool    `json:"enableAutoScaling,omitempty" yaml:"enableAutoScaling,omitempty"`
+	MaxPods           int64    `json:"maxPods,omitempty" yaml:"maxPods,omitempty"`
+	MaxCount          int64    `json:"maxCount,omitempty" yaml:"maxCount,omitempty"`
+	MinCount          int64    `json:"minCount,omitempty" yaml:"minCount,omitempty"`
+
+	// TODO remove fields when migrated to a terraform module that does not require them any more
+	AgentDNSPrefix string `json:"agentDnsPrefix,omitempty" yaml:"agentDnsPrefix,omitempty"`
+	Count          int64  `json:"count,omitempty" yaml:"count,omitempty"`
+}
+
+type AzureKubernetesServiceNodePool struct {
+	BaseNodePool `json:",inline" yaml:",inline"`
+
+	AvailabilityZones []string `json:"availabilityZones,omitempty" yaml:"availabilityZones,omitempty"`
+	CreatePoolPerZone bool     `json:"createPoolPerZone" yaml:"createPoolPerZone"`
+	EnableAutoScaling *bool    `json:"enableAutoScaling,omitempty" yaml:"enableAutoScaling,omitempty"`
+	MaxCount          int64    `json:"maxCount,omitempty" yaml:"maxCount,omitempty"`
+	MaxPods           int64    `json:"maxPods,omitempty" yaml:"maxPods,omitempty"`
+	MinCount          int64    `json:"minCount,omitempty" yaml:"minCount,omitempty"`
+	OsDiskSizeGB      int64    `json:"osDiskSize,omitempty" yaml:"osDiskSize,omitempty"`
+	Type              string   `json:"type,omitempty" yaml:"type,omitempty"`
+	Version           string   `json:"version,omitempty" yaml:"version,omitempty"`
+	VMSize            string   `json:"vmSize,omitempty" yaml:"vmSize,omitempty"`
 }
 
 //Schemas
@@ -164,29 +186,11 @@ func clusterAKSConfigFields() map[string]*schema.Schema {
 			Default:     "azureuser",
 			Description: "The administrator username to use for Linux hosts",
 		},
-		"agent_os_disk_size": {
-			Type:        schema.TypeInt,
-			Optional:    true,
-			Default:     0,
-			Description: "GB size to be used to specify the disk for every machine in the agent pool. If you specify 0, it will apply the default according to the \"agent vm size\" specified",
-		},
-		"agent_pool_name": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     "agentpool0",
-			Description: "Name for the agent pool, upto 12 alphanumeric characters",
-		},
 		"agent_storage_profile": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Default:     "ManagedDisks",
 			Description: "Storage profile specifies what kind of storage used on machine in the agent pool. Chooses from [ManagedDisks StorageAccount]",
-		},
-		"agent_vm_size": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     "Standard_D1_v2",
-			Description: "Size of machine in the agent pool",
 		},
 		"auth_base_url": {
 			Type:        schema.TypeString,
@@ -199,12 +203,6 @@ func clusterAKSConfigFields() map[string]*schema.Schema {
 			Optional:    true,
 			Default:     "https://management.azure.com/",
 			Description: "Different resource management API url to use",
-		},
-		"count": {
-			Type:        schema.TypeInt,
-			Optional:    true,
-			Default:     1,
-			Description: "Number of machines (VMs) in the agent pool. Allowed values must be in the range of 1 to 100 (inclusive)",
 		},
 		"dns_service_ip": {
 			Type:        schema.TypeString,
@@ -246,12 +244,6 @@ func clusterAKSConfigFields() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "The resource group of an existing Azure Log Analytics Workspace to use for storing monitoring data. If not specified, uses the 'Cluster' resource group",
 		},
-		"max_pods": {
-			Type:        schema.TypeInt,
-			Optional:    true,
-			Default:     110,
-			Description: "Maximum number of pods that can run on a node",
-		},
 		"network_plugin": {
 			Type:         schema.TypeString,
 			Optional:     true,
@@ -283,43 +275,146 @@ func clusterAKSConfigFields() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "Tags for Kubernetes cluster. For example, foo=bar",
 		},
-		"enable_auto_scaling": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "Enable auto-scaling of worker nodes",
-		},
-		"min_count": {
-			Type:        schema.TypeInt,
-			Optional:    true,
-			Default:     1,
-			Description: "Minimum number of worker nodes in the auto-scaling cluster",
-		},
-		"max_count": {
-			Type:        schema.TypeInt,
-			Optional:    true,
-			Default:     10,
-			Description: "Maximum number of worker nodes in the auto-scaling cluster",
-		},
-		"agent_pool_type": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     "AvailabilitySet",
-			Description: "Agent pool type (VirtualMachineScaleSets or AvailabilitySet).",
-		},
-		"availability_zones": {
-			Type:        schema.TypeList,
-			Optional:    true,
-			Description: "List of availability zones to use for the cluster",
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
-			},
-		},
 		"load_balancer_sku": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Default:     "Basic",
 			Description: "Load balancer type (must be standard for auto-scaling)",
+		},
+		"node_pools": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "List of node pools",
+			MinItems:    1,
+			Elem: &schema.Resource{
+				Schema: newNodePoolSchema(map[string]*schema.Schema{
+					"os_disk_size": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Default:     0,
+						Description: `GB size to be used to specify the disk for every node in pool. If you specify 0, it will apply the default according to the "vm size" specified`,
+					},
+					"vm_size": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Default:     "Standard_D1_v2",
+						Description: "Size of machine in the node pool",
+					},
+					"max_pods": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Default:     110,
+						Description: "Maximum number of pods that can run on a node",
+					},
+					"enable_auto_scaling": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Default:     false,
+						Description: "Enable auto-scaling of nodes in pool",
+					},
+					"min_count": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Default:     1,
+						Description: "Minimum number of nodes in pool",
+					},
+					"max_count": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Default:     10,
+						Description: "Maximum number of nodes in pool",
+					},
+					"type": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Default:     "AvailabilitySet",
+						Description: "Node pool type (VirtualMachineScaleSets or AvailabilitySet).",
+					},
+					"availability_zones": {
+						Type:        schema.TypeList,
+						Optional:    true,
+						Description: "List of availability zones to use for the pool",
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+					"version": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Kubernetes version for the pool",
+					},
+					"create_pool_per_zone": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Default:     true,
+						Description: "Whether it should create one pool per zone or not",
+					},
+				}),
+			},
+		},
+
+		// Deprecated fields
+		"agent_os_disk_size": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "GB size to be used to specify the disk for every machine in the agent pool. If you specify 0, it will apply the default according to the \"agent vm size\" specified",
+			Deprecated:  "Use 'node_pools' field instead",
+		},
+		"agent_pool_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Name for the agent pool, upto 12 alphanumeric characters",
+			Deprecated:  "Use 'node_pools' field instead",
+		},
+		"agent_vm_size": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Size of machine in the agent pool",
+			Deprecated:  "Use 'node_pools' field instead",
+		},
+		"count": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "Number of machines (VMs) in the agent pool. Allowed values must be in the range of 1 to 100 (inclusive)",
+			Deprecated:  "This field is not longer supported",
+		},
+		"max_pods": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "Maximum number of pods that can run on a node",
+			Deprecated:  "Use 'node_pools' field instead",
+		},
+		"enable_auto_scaling": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable auto-scaling of nodes",
+			Deprecated:  "Use 'node_pools' field instead",
+		},
+		"min_count": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "Minimum number of nodes in pool",
+			Deprecated:  "Use 'node_pools' field instead",
+		},
+		"max_count": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "Maximum number of nodes in pool",
+			Deprecated:  "Use 'node_pools' field instead",
+		},
+		"agent_pool_type": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Node pool type (VirtualMachineScaleSets or AvailabilitySet).",
+			Deprecated:  "Use 'node_pools' field instead",
+		},
+		"availability_zones": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "List of availability zones to use for the pool",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
 		},
 	}
 

--- a/rancher2/structure_cluster_aks_config_test.go
+++ b/rancher2/structure_cluster_aks_config_test.go
@@ -1,6 +1,7 @@
 package rancher2
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -8,10 +9,78 @@ import (
 var (
 	testClusterAKSConfigConf      *AzureKubernetesServiceConfig
 	testClusterAKSConfigInterface []interface{}
+
+	testClusterAKSConfigLegacyConf      *AzureKubernetesServiceConfig
+	testClusterAKSConfigLegacyInterface []interface{}
 )
 
 func init() {
+	nodePool := AzureKubernetesServiceNodePool{
+		BaseNodePool: BaseNodePool{
+			Name:             "agent",
+			AdditionalLabels: map[string]string{"label": "value"},
+			AdditionalTaints: []K8sTaint{
+				{Effect: "NoSchedule", Key: "taint_key", Value: "taint_value"},
+			},
+		},
+		AvailabilityZones: []string{"az1", "az2"},
+		CreatePoolPerZone: true,
+		EnableAutoScaling: newTrue(),
+		MaxCount:          33,
+		MaxPods:           100,
+		MinCount:          11,
+		OsDiskSizeGB:      16,
+		Type:              "agent_pool_type",
+		Version:           "agent_version",
+		VMSize:            "size",
+	}
+
+	nodePoolBytes, _ := json.Marshal(nodePool)
+
 	testClusterAKSConfigConf = &AzureKubernetesServiceConfig{
+		AADClientAppID:                     "add_client_app_id",
+		AADServerAppID:                     "add_server_app_id",
+		AADServerAppSecret:                 "aad_server_app_secret",
+		AADTenantID:                        "aad_tenant_id",
+		AdminUsername:                      "admin",
+		AgentDNSPrefix:                     "dns",
+		AgentStorageProfile:                "agent_storage_profile",
+		AuthBaseURL:                        "auth_base_url",
+		BaseURL:                            "url",
+		ClientID:                           "client_id",
+		ClientSecret:                       "client_secret",
+		Count:                              3,
+		DisplayName:                        "test",
+		DNSServiceIP:                       "dns_ip",
+		DockerBridgeCIDR:                   "192.168.1.0/16",
+		EnableHTTPApplicationRouting:       true,
+		EnableMonitoring:                   newTrue(),
+		KubernetesVersion:                  "version",
+		LoadBalancerSku:                    "load_balancer_sku",
+		Location:                           "location",
+		LogAnalyticsWorkspace:              "log_analytics_workspace",
+		LogAnalyticsWorkspaceResourceGroup: "log_analytics_workspace_resource_group",
+		MasterDNSPrefix:                    "dns_prefix",
+		Name:                               "test",
+		NodePools:                          []string{string(nodePoolBytes)},
+		NetworkPlugin:                      "network_plugin",
+		NetworkPolicy:                      "network_policy",
+		PodCIDR:                            "pod_cidr",
+		ResourceGroup:                      "resource_group",
+		SSHPublicKeyContents:               "key",
+		ServiceCIDR:                        "service_cidr",
+		Subnet:                             "subnet",
+		SubscriptionID:                     "subscription_id",
+		Tags: map[string]string{
+			"tag1": "value1",
+			"tag2": "value2",
+		},
+		TenantID:                    "tenant_id",
+		VirtualNetwork:              "virtual_network",
+		VirtualNetworkResourceGroup: "network_resource_group",
+	}
+
+	testClusterAKSConfigLegacyConf = &AzureKubernetesServiceConfig{
 		AADClientAppID:                     "add_client_app_id",
 		AADServerAppID:                     "add_server_app_id",
 		AADServerAppSecret:                 "aad_server_app_secret",
@@ -61,6 +130,7 @@ func init() {
 		VirtualNetwork:              "virtual_network",
 		VirtualNetworkResourceGroup: "network_resource_group",
 	}
+
 	testClusterAKSConfigInterface = []interface{}{
 		map[string]interface{}{
 			"add_client_app_id":                      "add_client_app_id",
@@ -69,20 +139,14 @@ func init() {
 			"aad_tenant_id":                          "aad_tenant_id",
 			"admin_username":                         "admin",
 			"agent_dns_prefix":                       "dns",
-			"agent_os_disk_size":                     16,
-			"agent_pool_name":                        "agent",
-			"agent_pool_type":                        "agent_pool_type",
 			"agent_storage_profile":                  "agent_storage_profile",
-			"agent_vm_size":                          "size",
 			"auth_base_url":                          "auth_base_url",
-			"availability_zones":                     []interface{}{"az1", "az2"},
 			"base_url":                               "url",
 			"client_id":                              "client_id",
 			"client_secret":                          "client_secret",
 			"count":                                  3,
 			"dns_service_ip":                         "dns_ip",
 			"docker_bridge_cidr":                     "192.168.1.0/16",
-			"enable_auto_scaling":                    true,
 			"enable_http_application_routing":        true,
 			"enable_monitoring":                      true,
 			"kubernetes_version":                     "version",
@@ -91,17 +155,97 @@ func init() {
 			"log_analytics_workspace":                "log_analytics_workspace",
 			"log_analytics_workspace_resource_group": "log_analytics_workspace_resource_group",
 			"master_dns_prefix":                      "dns_prefix",
-			"max_count":                              33,
-			"max_pods":                               100,
-			"min_count":                              11,
 			"network_plugin":                         "network_plugin",
 			"network_policy":                         "network_policy",
-			"pod_cidr":                               "pod_cidr",
-			"resource_group":                         "resource_group",
-			"ssh_public_key_contents":                "key",
-			"service_cidr":                           "service_cidr",
-			"subnet":                                 "subnet",
-			"subscription_id":                        "subscription_id",
+			"node_pools": []interface{}{
+				map[string]interface{}{
+					"add_default_label": false,
+					"add_default_taint": false,
+					"additional_labels": map[string]interface{}{"label": "value"},
+					"additional_taints": []interface{}{
+						map[string]interface{}{
+							"effect": "NoSchedule",
+							"key":    "taint_key",
+							"value":  "taint_value",
+						},
+					},
+					"availability_zones":   []interface{}{"az1", "az2"},
+					"create_pool_per_zone": true,
+					"enable_auto_scaling":  true,
+					"max_count":            33,
+					"max_pods":             100,
+					"min_count":            11,
+					"name":                 "agent",
+					"os_disk_size":         16,
+					"version":              "agent_version",
+					"vm_size":              "size",
+					"type":                 "agent_pool_type",
+				},
+			},
+			"pod_cidr":                "pod_cidr",
+			"resource_group":          "resource_group",
+			"ssh_public_key_contents": "key",
+			"service_cidr":            "service_cidr",
+			"subnet":                  "subnet",
+			"subscription_id":         "subscription_id",
+			"tags": map[string]interface{}{
+				"tag1": "value1",
+				"tag2": "value2",
+			},
+			"tenant_id":                      "tenant_id",
+			"virtual_network":                "virtual_network",
+			"virtual_network_resource_group": "network_resource_group",
+		},
+	}
+
+	testClusterAKSConfigLegacyInterface = []interface{}{
+		map[string]interface{}{
+			"add_client_app_id":                      "add_client_app_id",
+			"add_server_app_id":                      "add_server_app_id",
+			"aad_server_app_secret":                  "aad_server_app_secret",
+			"aad_tenant_id":                          "aad_tenant_id",
+			"admin_username":                         "admin",
+			"agent_dns_prefix":                       "dns",
+			"agent_storage_profile":                  "agent_storage_profile",
+			"auth_base_url":                          "auth_base_url",
+			"base_url":                               "url",
+			"client_id":                              "client_id",
+			"client_secret":                          "client_secret",
+			"count":                                  3,
+			"dns_service_ip":                         "dns_ip",
+			"docker_bridge_cidr":                     "192.168.1.0/16",
+			"enable_http_application_routing":        true,
+			"enable_monitoring":                      true,
+			"kubernetes_version":                     "version",
+			"load_balancer_sku":                      "load_balancer_sku",
+			"location":                               "location",
+			"log_analytics_workspace":                "log_analytics_workspace",
+			"log_analytics_workspace_resource_group": "log_analytics_workspace_resource_group",
+			"master_dns_prefix":                      "dns_prefix",
+			"network_plugin":                         "network_plugin",
+			"network_policy":                         "network_policy",
+			"node_pools": []interface{}{
+				map[string]interface{}{
+					"add_default_label":    false,
+					"add_default_taint":    false,
+					"availability_zones":   []interface{}{"az1", "az2"},
+					"create_pool_per_zone": true,
+					"enable_auto_scaling":  true,
+					"max_count":            33,
+					"max_pods":             100,
+					"min_count":            11,
+					"name":                 "agent",
+					"os_disk_size":         16,
+					"vm_size":              "size",
+					"type":                 "agent_pool_type",
+				},
+			},
+			"pod_cidr":                "pod_cidr",
+			"resource_group":          "resource_group",
+			"ssh_public_key_contents": "key",
+			"service_cidr":            "service_cidr",
+			"subnet":                  "subnet",
+			"subscription_id":         "subscription_id",
 			"tags": map[string]interface{}{
 				"tag1": "value1",
 				"tag2": "value2",
@@ -115,25 +259,31 @@ func init() {
 
 func TestFlattenClusterAKSConfig(t *testing.T) {
 
-	cases := []struct {
+	cases := map[string]struct {
 		Input          *AzureKubernetesServiceConfig
 		ExpectedOutput []interface{}
 	}{
-		{
+		"AKSCluster": {
 			testClusterAKSConfigConf,
 			testClusterAKSConfigInterface,
 		},
+		"AKSLegacyCluster": {
+			testClusterAKSConfigLegacyConf,
+			testClusterAKSConfigLegacyInterface,
+		},
 	}
 
-	for _, tc := range cases {
-		output, err := flattenClusterAKSConfig(tc.Input)
-		if err != nil {
-			t.Fatalf("[ERROR] on flattener: %#v", err)
-		}
-		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
-			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
-				tc.ExpectedOutput, output)
-		}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			output, err := flattenClusterAKSConfig(tc.Input)
+			if err != nil {
+				t.Fatalf("[ERROR] on flattener: %#v", err)
+			}
+			if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+				t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+					tc.ExpectedOutput, output)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
What
----
As part of [1], support for multiple node pools will be
added to kontainer-engine for AKS.

These are the required changes to provider in order to
use the new API.

References
----
[1] https://confluentinc.atlassian.net/browse/CIRE-1952

Test&Review
----
Performed tests:
* Create AKS cluster with previous provider and update with this version
* Create AKS cluster and update it with this version of the provider