### PR TITLE
add EKS' createPoolPerSubnet field

### DIFF
--- a/rancher2/schema_cluster_eks_config.go
+++ b/rancher2/schema_cluster_eks_config.go
@@ -37,6 +37,7 @@ type AmazonElasticContainerWorkerPool struct {
 
 	AMI                         string   `json:"ami,omitempty" yaml:"ami,omitempty"`
 	AssociateWorkerNodePublicIP *bool    `json:"associateWorkerNodePublicIp,omitempty" yaml:"associateWorkerNodePublicIp,omitempty"`
+	CreatePoolPerSubnet         bool     `json:"createPoolPerSubnet" yaml:"createPoolPerSubnet"`
 	DesiredNodes                int64    `json:"desiredNodes,omitempty" yaml:"desiredNodes,omitempty"`
 	EBSEncryption               bool     `json:"ebsEncryption,omitempty" yaml:"ebsEncryption,omitempty"`
 	InstanceType                string   `json:"instanceType,omitempty" yaml:"instanceType,omitempty"`
@@ -143,6 +144,12 @@ func clusterEKSConfigFields() map[string]*schema.Schema {
 						Optional:    true,
 						Default:     true,
 						Description: "Associate public ip EKS worker nodes",
+					},
+					"create_pool_per_subnet": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Default:     true,
+						Description: "Whether to create a pool per subnet or one pool for all subnets",
 					},
 					"desired_nodes": {
 						Type:        schema.TypeInt,

--- a/rancher2/structure_cluster_eks_config.go
+++ b/rancher2/structure_cluster_eks_config.go
@@ -74,6 +74,7 @@ func flattenClusterEKSConfig(in *AmazonElasticContainerServiceConfig) ([]interfa
 		}
 
 		workerPoolObj["associate_worker_node_public_ip"] = *workerPool.AssociateWorkerNodePublicIP
+		workerPoolObj["create_pool_per_subnet"] = workerPool.CreatePoolPerSubnet
 
 		if workerPool.DesiredNodes > 0 {
 			workerPoolObj["desired_nodes"] = int(workerPool.DesiredNodes)
@@ -215,6 +216,10 @@ func expandClusterEKSWorkerPool(workerPoolIn map[string]interface{}) (string, er
 
 	if v, ok := workerPoolIn["associate_worker_node_public_ip"].(bool); ok {
 		workerPoolObj.AssociateWorkerNodePublicIP = &v
+	}
+
+	if v, ok := workerPoolIn["create_pool_per_subnet"].(bool); ok {
+		workerPoolObj.CreatePoolPerSubnet = v
 	}
 
 	if v, ok := workerPoolIn["desired_nodes"].(int); ok && v > 0 {

--- a/rancher2/structure_cluster_eks_config_test.go
+++ b/rancher2/structure_cluster_eks_config_test.go
@@ -88,6 +88,7 @@ func init() {
 					},
 					"ami":                             "ami",
 					"associate_worker_node_public_ip": true,
+					"create_pool_per_subnet":          false,
 					"desired_nodes":                   4,
 					"ebs_encryption":                  false,
 					"instance_type":                   "instance",


### PR DESCRIPTION
What
----
As part of [1], support for creating a single autoscaling group for all subnets for a given node pool has been implemented. 

Adding the field to the provider.

References
----
[1] https://confluentinc.atlassian.net/browse/CIRE-2275
Depends on: https://github.com/confluentinc/kontainer-engine/pull/76

Test&Review
----
Tests:
1. EKS cluster created with current version of the module and upgraded with version from this PR
1. EKS cluster created with version from this PR